### PR TITLE
Destination arg for geo_proc; handler line 60

### DIFF
--- a/src/cumulus_geoproc/geoprocess/handler.py
+++ b/src/cumulus_geoproc/geoprocess/handler.py
@@ -60,6 +60,7 @@ def handle_message(geoprocess: str, GeoCfg: namedtuple, dst: str):
             proc_list = geo_proc(
                 plugin=GeoCfg.acquirable_slug,
                 src=src,
+                dst=dst,
                 acquirable=GeoCfg.acquirable_slug,
             )
 


### PR DESCRIPTION
`geo_proc()` needs to have `dst=dst` if `process` method in plugins does not have `dst = ` a path.  Currently, `dst = None`